### PR TITLE
fix: dearpygui texture formats usage error

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -3,22 +3,30 @@ import numpy as np
 from array import array
 from stylegan2 import Generator
 import torch
+import platform
 
 device = 'cpu'
 add_point = 0
 point_color = [(1, 0, 0), (0, 0, 1)]
 points = []
 image_width, image_height, channel = 256, 256, 3
+texture_format = dpg.mvFormat_Float_rgb
 generator = Generator(256, 512, 8)
 
 dpg.create_context()
 dpg.create_viewport(title='DragGAN', width=800, height=650)
 
+# mvFormat_Float_rgb not currently supported on MacOS
+# More details: https://dearpygui.readthedocs.io/en/latest/documentation/textures.html#formats
+if "macos" in platform.platform().lower():
+    channel = 4
+    texture_format = dpg.mvFormat_Float_rgba
+
 raw_data = array('f', [1]*(image_width*image_height*channel))
 with dpg.texture_registry(show=False):
     dpg.add_raw_texture(
         width=image_width, height=image_height, default_value=raw_data,
-        format=dpg.mvFormat_Float_rgb, tag="image"
+        format=texture_format, tag="image"
     )
 
 def generate_image(sender, app_data, user_data):


### PR DESCRIPTION
### What I do:
To fix this issue #4, switch dearpygui raw texture format to **mvFormat_Float_rgba** on macOS.

### Reason:
dearpygui add_raw_texture support **mvFormat_Float_rgb**, but not currently supported on macOS.

<img width="500" alt="469550fd-b6a5-41fa-91ab-e98273705137" src="https://github.com/JiauZhang/DragGAN/assets/49814337/479db2e1-9e82-4960-b49a-daa3065da722">

### Result:
#### Before Fix:
<img width="500" alt="053403bd-8ef1-4a52-a2b8-2b3a060cd35b" src="https://github.com/JiauZhang/DragGAN/assets/49814337/d9f2fc4f-9b2a-4991-b4b1-0130987d7147">

#### After Fix:
<img width="500" alt="2d3fde98-56a2-4d69-a3bb-7a9d3f4adef6" src="https://github.com/JiauZhang/DragGAN/assets/49814337/25ed4dd5-8661-406a-82f9-50cdbfca9461">


