### PR TITLE
fix: dearpygui texture formats usage error

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -3,28 +3,24 @@ import numpy as np
 from array import array
 from stylegan2 import Generator
 import torch
-import platform
 
 device = 'cpu'
 add_point = 0
 point_color = [(1, 0, 0), (0, 0, 1)]
 points = []
+
+# mvFormat_Float_rgb not currently supported on macOS
+# More details: https://dearpygui.readthedocs.io/en/latest/documentation/textures.html#formats
+texture_format = dpg.mvFormat_Float_rgba
 image_width, image_height, rgb_channel, rgba_channel = 256, 256, 3, 4
-texture_format = dpg.mvFormat_Float_rgb
+image_pixels = image_height * image_width
 generator = Generator(256, 512, 8)
 
 dpg.create_context()
 dpg.create_viewport(title='DragGAN', width=800, height=650)
 
-# mvFormat_Float_rgb not currently supported on macOS
-# More details: https://dearpygui.readthedocs.io/en/latest/documentation/textures.html#formats
-if "macos" in platform.platform().lower():
-    channel = rgba_channel
-    texture_format = dpg.mvFormat_Float_rgba
-else:
-    channel = rgb_channel
-
-raw_data = array('f', [1]*(image_width*image_height*channel))
+raw_data_size = image_width * image_height * rgba_channel
+raw_data = array('f', [1] * raw_data_size)
 with dpg.texture_registry(show=False):
     dpg.add_raw_texture(
         width=image_width, height=image_height, default_value=raw_data,
@@ -32,22 +28,14 @@ with dpg.texture_registry(show=False):
     )
 
 def generate_image(sender, app_data, user_data):
-    global raw_data
-    img_count = image_width*image_height*rgb_channel
     with torch.no_grad():
         z = torch.randn(1, 512).to(device)
         image = generator([z])[0][0].detach().cpu().permute(1, 2, 0).numpy()
-    image = (image / 2 + 0.5).clip(0, 1).reshape(img_count)
-    # Convert image data (rgb) to raw_data (rgb or rgba)
-    if "macos" in platform.platform().lower():
-        for i in range(0, img_count):
-            if i % rgb_channel == 0:
-                j = int(i / rgb_channel) * rgba_channel
-            raw_data[j] = image[i]
-            j+=1
-    else:
-        for i in range(0, img_count):
-            raw_data[i] = image[i]
+    image = (image / 2 + 0.5).clip(0, 1).reshape(-1)
+    # Convert image data (rgb) to raw_data (rgba)
+    for i in range(0, image_pixels):
+        rd_base, im_base = i * rgba_channel, i * rgb_channel
+        raw_data[rd_base:rd_base + rgb_channel] = array('f', image[im_base:im_base + rgb_channel])
 
 def change_device(sender, app_data):
     global device, generator
@@ -141,10 +129,8 @@ def draw_point(x, y, color):
     y_start, y_end = max(0, y - 2), min(image_height, y + 2)
     for x in range(x_start, x_end):
         for y in range(y_start, y_end):
-            offset = (y*image_width+x)*channel
-            raw_data[offset] = color[0]
-            raw_data[offset+1] = color[1]
-            raw_data[offset+2] = color[2]
+            offset = (y * image_width + x) * rgba_channel
+            raw_data[offset:offset + rgb_channel] = array('f', color[:rgb_channel])
 
 def select_point(sender, app_data):
     global add_point, points

--- a/gui.py
+++ b/gui.py
@@ -3,32 +3,51 @@ import numpy as np
 from array import array
 from stylegan2 import Generator
 import torch
+import platform
 
 device = 'cpu'
 add_point = 0
 point_color = [(1, 0, 0), (0, 0, 1)]
 points = []
-image_width, image_height, channel = 256, 256, 3
+image_width, image_height, rgb_channel, rgba_channel = 256, 256, 3, 4
+texture_format = dpg.mvFormat_Float_rgb
 generator = Generator(256, 512, 8)
 
 dpg.create_context()
 dpg.create_viewport(title='DragGAN', width=800, height=650)
 
+# mvFormat_Float_rgb not currently supported on macOS
+# More details: https://dearpygui.readthedocs.io/en/latest/documentation/textures.html#formats
+if "macos" in platform.platform().lower():
+    channel = rgba_channel
+    texture_format = dpg.mvFormat_Float_rgba
+else:
+    channel = rgb_channel
+
 raw_data = array('f', [1]*(image_width*image_height*channel))
 with dpg.texture_registry(show=False):
     dpg.add_raw_texture(
         width=image_width, height=image_height, default_value=raw_data,
-        format=dpg.mvFormat_Float_rgb, tag="image"
+        format=texture_format, tag="image"
     )
 
 def generate_image(sender, app_data, user_data):
-    count = image_width*image_height*channel
+    global raw_data
+    img_count = image_width*image_height*rgb_channel
     with torch.no_grad():
         z = torch.randn(1, 512).to(device)
         image = generator([z])[0][0].detach().cpu().permute(1, 2, 0).numpy()
-    image = (image / 2 + 0.5).clip(0, 1).reshape(count)
-    for i in range(0, count):
-        raw_data[i] = image[i]
+    image = (image / 2 + 0.5).clip(0, 1).reshape(img_count)
+    # Convert image data (rgb) to raw_data (rgb or rgba)
+    if "macos" in platform.platform().lower():
+        for i in range(0, img_count):
+            if i % rgb_channel == 0:
+                j = int(i / rgb_channel) * rgba_channel
+            raw_data[j] = image[i]
+            j+=1
+    else:
+        for i in range(0, img_count):
+            raw_data[i] = image[i]
 
 def change_device(sender, app_data):
     global device, generator
@@ -122,7 +141,7 @@ def draw_point(x, y, color):
     y_start, y_end = max(0, y - 2), min(image_height, y + 2)
     for x in range(x_start, x_end):
         for y in range(y_start, y_end):
-            offset = (y*image_width+x)*3
+            offset = (y*image_width+x)*channel
             raw_data[offset] = color[0]
             raw_data[offset+1] = color[1]
             raw_data[offset+2] = color[2]


### PR DESCRIPTION
### What I do:
To fix this issue #4, switch dearpygui raw texture format to **mvFormat_Float_rgba** on macOS.

### Reason:
dearpygui add_raw_texture support **mvFormat_Float_rgb**, but not currently supported on macOS.

<img width="500" alt="469550fd-b6a5-41fa-91ab-e98273705137" src="https://github.com/JiauZhang/DragGAN/assets/49814337/479db2e1-9e82-4960-b49a-daa3065da722">

### Result:
#### Before Fix:
<img width="500" alt="053403bd-8ef1-4a52-a2b8-2b3a060cd35b" src="https://github.com/JiauZhang/DragGAN/assets/49814337/d9f2fc4f-9b2a-4991-b4b1-0130987d7147">

#### After Fix:
<img width="500" alt="2d3fde98-56a2-4d69-a3bb-7a9d3f4adef6" src="https://github.com/JiauZhang/DragGAN/assets/49814337/25ed4dd5-8661-406a-82f9-50cdbfca9461">

<img width="500" alt="cae3dbd1-da98-45f6-b618-81fc5345a587" src="https://github.com/JiauZhang/DragGAN/assets/49814337/23210cd1-2282-417e-9784-c74990f40f5c">

