### PR TITLE
fix: add requirements.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Implementation of [DragGAN: Interactive Point-based Manipulation on the Generati
 
 ```shell
 # gui
-pip install dearpygui
+pip install -r requirements.txt
 # run demo
 python gui.py
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,10 @@
+dearpygui==1.9.1
+filelock==3.12.0
+Jinja2==3.1.2
+MarkupSafe==2.1.2
+mpmath==1.3.0
+networkx==3.1
+numpy==1.24.3
+sympy==1.12
+torch==2.0.1
+typing_extensions==4.6.2


### PR DESCRIPTION
there's quite a few of these PRs around. does seem like the requirements.txt files differ a lot. 

I believe this one should be it. The only direct deps are `dearpygui`, `numpy`, and `torch`, but we can lock versions for its deps as well.

